### PR TITLE
fix: Fix "commenter_exitcode" code-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
       with:
         commenter_type: plan
         commenter_plan_path: tf_plan.txt
-        commenter_exitcode: ${{ steps.plan.outputs.exit }}
+        commenter_exitcode: ${{ steps.plan.outputs.exitcode }}
 ```
 
 ### Inputs


### PR DESCRIPTION
Ensure even the last step uses the correct exit-code of the `plan`-step.